### PR TITLE
Add 2in7 v2

### DIFF
--- a/home.admin/config.ini
+++ b/home.admin/config.ini
@@ -7,6 +7,7 @@ fiat = eur
 # Default value is 2in7_4gray
 #epd_type = 2in7_4gray
 #epd_type = 2in7
+#epd_type = 2in7_V2
 #epd_type = 2in9_V2
 #epd_type = 7in5_V2
 #epd_type = 7in5_HD

--- a/home.admin/tickerEink.py
+++ b/home.admin/tickerEink.py
@@ -17,7 +17,7 @@ import signal
 import atexit
 import sdnotify
 import RPi.GPIO as GPIO
-from waveshare_epd import epd2in7, epd7in5_HD, epd7in5_V2, epd2in9_V2
+from waveshare_epd import epd2in7, epd2in7_V2, epd7in5_HD, epd7in5_V2, epd2in9_V2
 import time
 from PIL import Image, ImageOps
 from PIL import ImageFont
@@ -76,6 +76,10 @@ def get_display_size(epd_type):
         epd = epd2in7.EPD()
         mirror = False
         return epd.width, epd.height, mirror
+    elif epd_type == "2in7_V2":
+        epd = epd2in7_V2.EPD()
+        mirror = False
+        return epd.width, epd.height, mirror
     elif epd_type == "2in9_V2":
         epd = epd2in9_V2.EPD()
         mirror = False
@@ -104,6 +108,13 @@ def draw_image(epd_type, image=None):
         epd.display_4Gray(epd.getbuffer_4Gray(image))
     elif epd_type == "2in7":
         epd = epd2in7.EPD()
+        epd.init()
+        if image is None:
+            image = Image.new('L', (epd.height, epd.width), 255)
+        logging.info("draw")
+        epd.display(epd.getbuffer(image))
+    elif epd_type == "2in7_V2":
+        epd = epd2in7_V2.EPD()
         epd.init()
         if image is None:
             image = Image.new('L', (epd.height, epd.width), 255)

--- a/tickerGUI.py
+++ b/tickerGUI.py
@@ -10,6 +10,8 @@ import time
 def get_display_size(epd_type="2in7_4gray"):
     if epd_type == "2in7":
         return 176, 264
+    elif epd_type == "2in7_V2":
+        return 176, 264
     elif epd_type == "2in7_4gray":
         return 176, 264
     elif epd_type == "2in9_V2":


### PR DESCRIPTION
Waveshare add a new 2.7 inch e-Paper HAT Display version 2. This Pull Request adds support for 2in7_V2.
It has been tested. Old BTC tickers should first update the e-paper directory via "git pull" to download the latest driver.

![image](https://github.com/btc-ticker/btc-ticker/assets/84231978/dab0448f-122d-420c-9d21-c0fd3875e6d5)
